### PR TITLE
better error handling

### DIFF
--- a/lib/chargify/client.rb
+++ b/lib/chargify/client.rb
@@ -5,7 +5,7 @@ module Chargify
   class Parser < HTTParty::Parser
     def parse
       begin
-        Crack::JSON.parse(body)
+        Crack::JSON.parse(body) || {}
       rescue => e
         raise UnexpectedResponseError, "Crack could not parse JSON. It said: #{e.message}. Chargify's raw response: #{body}"
       end
@@ -230,7 +230,6 @@ module Chargify
     
       def jsonify_body!(options)
         options[:body] = options[:body].to_json if options[:body]
-
       end
   end
 end

--- a/test/chargify_test.rb
+++ b/test/chargify_test.rb
@@ -338,6 +338,12 @@ class ChargifyTest < Test::Unit::TestCase
         component.name.should == "Extra Rubies"
         component.allocated_quantity.should == 42
       end
+
+      should "return nil if the component is not found" do
+        stub_get "https://OU812:x@pengwynn.chargify.com/subscriptions/123/components/16.json", "", 404
+        component = @client.subscription_component 123, 16
+        component.should == nil
+      end
       
       should "update the allocated_quantity for a component" do
         stub_put "https://OU812:x@pengwynn.chargify.com/subscriptions/123/components/16.json", "component.json"
@@ -368,6 +374,14 @@ class ChargifyTest < Test::Unit::TestCase
         stub_put "https://OU812:x@pengwynn.chargify.com/subscriptions/123/components/16.json", "component.json"
         response = @client.update_subscription_component_enabled 123, 16, true
         response.success?.should == true
+      end
+
+      context "when there is an error" do
+        should "return :success? => false" do
+          stub_put "https://OU812:x@pengwynn.chargify.com/subscriptions/123/components/16.json", "", 404
+          response = @client.update_subscription_component_enabled 123, 16, true
+          response.success?.should == false
+        end
       end
     end
 


### PR DESCRIPTION
We had some blow ups in production.  A few of the methods weren't protected against 404 responses so I handled it at the level of the parser instead of each method.  Added failing specs for the blowups we were getting in production.  All tests pass.
