### PR TITLE
Configure the project so that it can be built using bundler.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "http://rubygems.org"
+
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,34 @@
+PATH
+  remote: .
+  specs:
+    chargify (0.3.0)
+      hashie (~> 1.0.0)
+      httparty (~> 0.7.4)
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    crack (0.1.8)
+    fakeweb (1.3.0)
+    hashie (1.0.0)
+    httparty (0.7.7)
+      crack (= 0.1.8)
+    jnunemaker-matchy (0.4.0)
+    mg (0.0.8)
+      rake
+    mocha (0.9.12)
+    rake (0.9.1)
+    shoulda (2.11.3)
+    test-unit (2.3.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  chargify!
+  fakeweb (>= 1.2.5)
+  jnunemaker-matchy (= 0.4.0)
+  mg (>= 0.0.8)
+  mocha (~> 0.9.8)
+  shoulda (>= 2.10.1)
+  test-unit (>= 2.3.0)

--- a/chargify.gemspec
+++ b/chargify.gemspec
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 
-require File.dirname(__FILE__) + '/lib/chargify.rb'
+require File.dirname(__FILE__) + '/lib/chargify/version.rb'
 
 Gem::Specification.new do |s|
   s.name = %q{chargify}

--- a/lib/chargify.rb
+++ b/lib/chargify.rb
@@ -6,8 +6,5 @@ directory = File.expand_path(File.dirname(__FILE__))
 
 Hash.send :include, Hashie::HashExtensions
 
+require File.join(directory, 'chargify', 'version')
 require File.join(directory, 'chargify', 'client')
-
-module Chargify
-  VERSION = "0.3.0".freeze
-end

--- a/lib/chargify/version.rb
+++ b/lib/chargify/version.rb
@@ -1,0 +1,3 @@
+module Chargify
+  VERSION = "0.3.0".freeze
+end


### PR DESCRIPTION
I added a Gemfile to the project to make it easier to checkout and build.

I had to adjust the gemspec so that it doesn't have direct dependancies on external gems. This was achieved by moving the VERSION constant into a separate file and just requiring that.
